### PR TITLE
Moved Google Books API Key to .env

### DIFF
--- a/src/components/categories/Textbooks.jsx
+++ b/src/components/categories/Textbooks.jsx
@@ -17,7 +17,7 @@ const config = {
 };
 
 const googleAPI = "https://www.googleapis.com/books/v1/volumes";
-const googleAPIKey = 'AIzaSyB5xY_lIKmpdwTI50kPz-UYiBDmyiSoc5M'
+const googleAPIKey = process.env.REACT_APP_GOOGLE_BOOKS_API_KEY
 
 // Add objects parameter; list of lists (info for InfoCards)
 class Textbooks extends React.Component {


### PR DESCRIPTION
I will be updating the environment variable file on AWS, as well as cleaning up our commit history to remove records of this API key being exposed. Make sure to add REACT_APP_GOOGLE_BOOKS_API_KEY to your .env file!